### PR TITLE
Update metadata inside package.json and update README.md broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A shareable ESLint configuration that enforces a consistent JavaScript/React cod
 
 ## Installation
 
-1. First, install the package along with its peer dependencies:
+First, install the package along with its peer dependencies:
 
 ```bash
 npm install --save-dev eslint-config-helpshift

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To use Helpshift style in conjunction with ESLint's recommended rule set, extend
 }
 ```
 
-To see how the `helpshift` config compares with `eslint:recommended`, refer to the [source code of `index.js`](https://github.com/helpshift/eslint-config-helpshift/blob/main/index.js), which lists every ESLint rule along with whether (and how) it is enforced by the `helpshift` config.
+To see how the `helpshift` config compares with `eslint:recommended`, refer to the [source code of index.js](https://github.com/helpshift/eslint-config-helpshift/blob/master/index.js), which lists every ESLint rule along with whether (and how) it is enforced by the `helpshift` config.
 
 ## Editor Integration
 
@@ -100,8 +100,8 @@ For the best experience, we recommend integrating ESLint with your editor:
 
 ## Contributing
 
-If you'd like to contribute to this ESLint config, please see our [Contributing Guidelines](CONTRIBUTING.md).
+If you'd like to contribute to this ESLint config, please see our [Contributing Guidelines](https://github.com/helpshift/eslint-config-helpshift/blob/master/CONTRIBUTING.md).
 
 ## License
 
-[MIT](LICENSE) © Helpshift
+[MIT](https://github.com/helpshift/eslint-config-helpshift/blob/master/LICENSE) © Helpshift

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@helpshiftdev/eslint-config-hs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,23 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://gerrit/eslint-config.git"
+    "url": "https://github.com/helpshift/eslint-config-helpshift"
   },
   "keywords": [
     "eslint",
-    "eslintconfig"
+    "eslint-config",
+    "eslintconfig",
+    "helpshift",
+    "javascript",
+    "react",
+    "jsx",
+    "code-style",
+    "lint",
+    "prettier",
+    "eslint-rules",
+    "style-guide",
+    "code-quality",
+    "best-practices"
   ],
   "exports": {
     ".": "./index.js",
@@ -32,6 +44,10 @@
     "url": "https://developers.helpshift.com"
   },
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/helpshift/eslint-config-helpshift/issues"
+  },
+  "homepage": "https://github.com/helpshift/eslint-config-helpshift",
   "peerDependencies": {
     "eslint": ">= 7.0.0",
     "eslint-plugin-prettier": ">= 3.4.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "keywords": [
     "eslint",
-    "eslint-config",
     "eslintconfig",
     "helpshift",
     "javascript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-helpshift",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shareable ESLINT config containing rules used at Helpshift.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Change**:
- Currently, if you check the `eslint-config-helpshift` package inside [NPM](https://www.npmjs.com/package/eslint-config-helpshift), the GitHub repository, and other metadata information, such a keywords (tags), need an update.
- Update the links in the README.md